### PR TITLE
BUG: Simple has base typography defined in layout (trac #7803)

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -56,46 +56,7 @@ a.btn:hover {
     background: #d80000;
     color: #fff;
 }
-.content img {
-    border: 5px solid #d7d7d7;
-    max-width: 60%;
-    height: auto;
-    float: left;
-    margin: 6px 20px 10px 0;
-}
-.content ul {
-    margin: 20px 0 20px 30px
-}
-.content li {
-    line-height: 22px;
-    margin-bottom: 5px;
-    list-style-type: disc;
-}
-.content-container h1 {
-    font-size: 36px;
-    border-bottom: 1px solid #e5e5e5;
-    padding-bottom: 6px;
-    margin: 0 0 23px 0;
-    line-height: 45px;
-}
-	.content-container h1 span.amp {
-	    font-family: Baskerville,"Goudy Old Style","Palatino","Book Antiqua",Georgia;
-	    font-style: italic;
-	}
-.content-container h2 {
-    font-size: 24px;
-    margin-bottom: 15px;
-    padding-top: 15px;
-    line-height: 32px;
-}
-.content-container h3 {
-    font-size: 21px;
-    margin-bottom: 10px;
-    padding-top: 10px;
-}
-.content a {
-    border-bottom: 1px dashed #b80000
-}
+
 .brand {
     float: left;
     display: inline-block;
@@ -615,12 +576,12 @@ aside {
 	aside {
 	    width: 100%
 	}
-		.content-container h1 {
+		.typography h1 {
 		    font-size: 30px;
 		    margin-bottom: 15px;
 		    padding-bottom: 3px;
 		}
-		.content-container p {
+		.typography p {
 		    font-size: 14px;
 		    line-height: 23px;
 		}

--- a/css/typography.css
+++ b/css/typography.css
@@ -42,6 +42,53 @@ a {
 a:hover {
     color: #d80000
 }
+
+.typography h1 a{
+  border:none;
+}
+
+.typography img {
+    border: 5px solid #d7d7d7;
+    max-width: 60%;
+    height: auto;
+    float: left;
+    margin: 6px 20px 10px 0;
+}
+.typography ul {
+    margin: 20px 0 20px 30px
+}
+.typography li {
+    line-height: 22px;
+    margin-bottom: 5px;
+    list-style-type: disc;
+}
+.typography h1 {
+    font-size: 36px;
+    border-bottom: 1px solid #e5e5e5;
+    padding-bottom: 6px;
+    margin: 0 0 23px 0;
+    line-height: 45px;
+}
+  .typography h1 span.amp {
+      font-family: Baskerville,"Goudy Old Style","Palatino","Book Antiqua",Georgia;
+      font-style: italic;
+  }
+.typography h2 {
+   font-size: 24px;
+    margin-bottom: 15px;
+    padding-top: 15px;
+    line-height: 32px;
+}
+.typography h3 {
+    font-size: 21px;
+    margin-bottom: 10px;
+    padding-top: 10px;
+}
+.typography a {
+    border-bottom: 1px dashed #b80000
+}
+
+
 table {
     border-collapse: collapse;
     border: 1px solid #d4d4d4;

--- a/templates/Layout/Page.ss
+++ b/templates/Layout/Page.ss
@@ -1,4 +1,4 @@
-<div class="content-container typography">	
+<div class="content-container">	
 	<article>
 		<h1>$Title</h1>
 		<div class="content">$Content</div>

--- a/templates/Layout/Page_results.ss
+++ b/templates/Layout/Page_results.ss
@@ -1,4 +1,4 @@
-<div id="Content" class="searchResults typography">
+<div id="Content" class="searchResults">
     <h1>$Title</h1>
      
     <% if Query %>

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -30,7 +30,7 @@ Change it, enhance it and most importantly enjoy it!
 <body class="$ClassName<% if Menu(2) %><% else %> no-sidebar<% end_if %>">
 <% include Header %>
 <div class="main" role="main">
-	<div class="inner">
+	<div class="inner typography">
 		$Layout
 	</div>
 </div>


### PR DESCRIPTION
- Moved some style declarations from layout to typography so that the cms would pick them up.
- Moved typography tag to the page.ss before layout is included 
- Changed typography elements to be wrapped in .typography, rather than a layout tag within the Layout page templates. This will mean that a bunch of modules have access to the correct type styling (without having to change their internal templates)
