### PR TITLE
Fix for menu showing all sub-pages instead of children only

### DIFF
--- a/templates/Includes/SideBar.ss
+++ b/templates/Includes/SideBar.ss
@@ -1,16 +1,14 @@
 <aside>
 	<% if $Menu(2) %>
 		<nav class="secondary">
+				<% with $Level(1) %>
 			<h3>
-				<% loop $Level(1) %>
 					$Title
-				<% end_loop %>
 			</h3>
 			<ul>
-				<% loop $Menu(1) %>
 					<% include SidebarMenu %>
-				<% end_loop %>
 			</ul>
+				<% end_with %>
 		</nav>
 	<% end_if %>
 </aside>


### PR DESCRIPTION
Original version used <% loop $menu(1) %> which loops through all top level pages.

This version uses <% with $Level(1) %> to reference the current top level page only.
