### PR TITLE
BUG Fixed incorrect viewport meta tag

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -16,7 +16,7 @@ Change it, enhance it and most importantly enjoy it!
 	<% base_tag %>
 	<title><% if $MetaTitle %>$MetaTitle<% else %>$Title<% end_if %> &raquo; $SiteConfig.Title</title>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	$MetaTags(false)
 	<!--[if lt IE 9]>


### PR DESCRIPTION
Viewport meta tag was throwing up errors in Chrome for having an incorrect trailing ";".
