### PR TITLE
FIX Remove $MetaTitle

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -14,7 +14,7 @@ Change it, enhance it and most importantly enjoy it!
 <!--[if IE 8 ]><html lang="$ContentLocale" class="ie ie8"><![endif]-->
 <head>
 	<% base_tag %>
-	<title><% if $MetaTitle %>$MetaTitle<% else %>$Title<% end_if %> &raquo; $SiteConfig.Title</title>
+	<title>$Title &raquo; $SiteConfig.Title</title>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
CMS removed MetaTitle in 3.1 - this will not make sense to someone inspecting the theme code trying to learn from it.  (Unless we look to reinstate MetaTitle in 3.2? I know a lot of people have mentioned that it was very weird it was removed and that a meta title is an important out of the box item for a CMS).