### PR TITLE
Revert "FIX Remove $MetaTitle"

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -14,7 +14,7 @@ Change it, enhance it and most importantly enjoy it!
 <!--[if IE 8 ]><html lang="$ContentLocale" class="ie ie8"><![endif]-->
 <head>
 	<% base_tag %>
-	<title>$Title &raquo; $SiteConfig.Title</title>
+	<title><% if $MetaTitle %>$MetaTitle<% else %>$Title<% end_if %> &raquo; $SiteConfig.Title</title>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
Reverts silverstripe-themes/silverstripe-simple#31

Reasoning is that MetaTitle is still a useful function in user code, and doesn't necessarily rely on there being an actual database field for this feature.

Examples of cases this could be useful is where a specific page could customise the meta-title based on the current page action or parameter.