### PR TITLE
Use preferred 'error' style for messages

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -87,7 +87,9 @@ form .message {
         background-color: #ecf9d0;
         border-color: #8fbe00;
     }
-    form .bad, form .required {
+    form .bad,
+    form .required,
+    form .error {
         background-color: #f9d0d0;
         border-color: #cf0000;
         color: #b80000;


### PR DESCRIPTION
As per default jquery-validate settings, (https://github.com/jzaefferer/jquery-validation/blob/bc4223806a4608a68e46697b49e3f102b53d02aa/src/core.js#L227) we should use `error` as the error class for invalid fields and messages.