### PR TITLE
Use jQuery from CDN rather than framework

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -37,7 +37,7 @@ Change it, enhance it and most importantly enjoy it!
 </div>
 <% include Footer %>
 
-<% require javascript('framework/thirdparty/jquery/jquery.js') %>
+<% require javascript('http://code.jquery.com/jquery-1.7.2.min.js') %>
 <%-- Please move: Theme javascript (below) should be moved to mysite/code/page.php  --%>
 <script type="text/javascript" src="{$ThemeDir}/javascript/script.js"></script>
 


### PR DESCRIPTION
Merge with https://github.com/silverstripe/silverstripe-framework/pull/5918

Static asset paths in framework aren't a public API,
and hence shouldn't be relied on by other modules.

The template already includes some shim JS from the web,
so this doesn't change the fact that you need a network connection
to fully use the default theme.