### PR TITLE
UPDATE remove protocol from jquery request

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -37,7 +37,7 @@ Change it, enhance it and most importantly enjoy it!
 </div>
 <% include Footer %>
 
-<% require javascript('http://code.jquery.com/jquery-1.7.2.min.js') %>
+<% require javascript('//code.jquery.com/jquery-1.7.2.min.js') %>
 <%-- Please move: Theme javascript (below) should be moved to mysite/code/page.php  --%>
 <script type="text/javascript" src="{$ThemeDir}/javascript/script.js"></script>
 


### PR DESCRIPTION
With the increased focus on SSL, it's probably best not define http in the equest and let the page use the current protocol
