### PR TITLE
Fix for 3.5 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "composer/installers": "*",
-        "silverstripe/framework": ">=3.0"
+        "silverstripe/framework": ">=3.5"
     },
 	"extra": {
 		"branch-alias": {

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -38,7 +38,7 @@ Change it, enhance it and most importantly enjoy it!
 <% include Footer %>
 
 <% require javascript('//code.jquery.com/jquery-1.7.2.min.js') %>
-<% require themedJavascript('script.js') %>
+<% require themedJavascript('script') %>
 
 </body>
 </html>


### PR DESCRIPTION
the `.js` isn't necessary in 4.0 but it does break 3.5.