### PR TITLE
	FIX Remove $ThemeDir use from Page template

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -26,7 +26,7 @@ Change it, enhance it and most importantly enjoy it!
 	<% require themedCSS('typography') %>
 	<% require themedCSS('form') %>
 	<% require themedCSS('layout') %>
-	<link rel="shortcut icon" href="$ThemeDir/images/favicon.ico" />
+	<link rel="shortcut icon" href="themes/simple/images/favicon.ico" />
 </head>
 <body class="$ClassName<% if not $Menu(2) %> no-sidebar<% end_if %>" <% if $i18nScriptDirection %>dir="$i18nScriptDirection"<% end_if %>>
 <% include Header %>


### PR DESCRIPTION
This pull request removes the use of `$ThemeDir` from the Page template as per silverstripe/silverstripe-framework#6583.
