### PR TITLE
FIX Do not apply checkbox or radio formatting to the field holders

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -1,6 +1,6 @@
 /** ----------------------------------------------------------
  *
- * This stylesheet includes both generic form styles and 
+ * This stylesheet includes both generic form styles and
  *    additional form styles for the User Defined Form Module.
  *
  ** ------------------------------------------------------- */
@@ -62,12 +62,13 @@ textarea {
 
 
 /* Radio and Checkbox */
-.field .checkbox, .field .radio {
-    float: left; 
-    width: 13px; 
-    height: 13px; 
-    margin-right: 6px; 
-    margin-top: 3px;
+.field .checkbox:not(.field),
+.field .radio:not(.field) {
+    float: left;
+    width: 13px;
+    height: 13px;
+    margin-right: 6px;
+    margin-top: 5px;
     padding: 0;
 }
     .checkbox label.right,
@@ -236,7 +237,7 @@ div.holder-required {               /* This class needs to be changed - is used 
     margin-left: -11px; */
 }
 form input.holder-required {        /* This class needs to be changed - is used for both input and div */
-    border: 1px solid #cf0000; 
+    border: 1px solid #cf0000;
 }
 
 /* Error messages */
@@ -273,7 +274,7 @@ form #DMYDate-day {
 /* Responsive form styles
 ----------------------------------------------- */
 
-@media only screen and (max-width: 700px) { 
+@media only screen and (max-width: 700px) {
 
     /* To test - potentially not needed? */
 	.header form .middleColumn {
@@ -286,12 +287,12 @@ form #DMYDate-day {
 	}
 }
 
-@media only screen and (max-width: 900px) { 
+@media only screen and (max-width: 900px) {
     form {
         max-width: 100%;
     }
 }
 
-@media only screen and (min-width: 700px) { 
+@media only screen and (min-width: 700px) {
 
 }


### PR DESCRIPTION
**SS 3.6.0**

Don't apply checkbox styles to the holder for checkboxes (same for radios).

## Steps to reproduce

### frameworktest

* Vanilla SS 3.6.0
* `composer require silverstripe/frameworktest 3.1.x-dev`
* dev/build
* Go to `/feature-test-pages/basicfields?stage=Stage`
* Go to "Options" tab

### userforms

* Create a userforms page
* Add a radio button and/or checkbox field
* Give it/them a label
* Save and view on frontend

## HTML source code

### frameworktest

![image](https://user-images.githubusercontent.com/5170590/28255376-0fe76914-6b0a-11e7-979f-7b73993511ff.png)

### userforms

![image](https://user-images.githubusercontent.com/5170590/28255354-e72eb860-6b09-11e7-9bfd-0a22fb3b9d13.png)

## Screenshots before/after

### frameworktest

![frameworktest](https://user-images.githubusercontent.com/5170590/28255055-bb38ac3c-6b06-11e7-9945-cfddb695b0ea.png)

### userforms

![userforms](https://user-images.githubusercontent.com/5170590/28255079-144fbd6a-6b07-11e7-8b1a-a4198f02d3e8.png)

