### PR TITLE
ENHANCEMENT Declare exposed folders necessary for public webroot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,12 @@
 	"extra": {
 		"branch-alias": {
 			"dev-master": "3.2.x-dev"
-		}
+		},
+        "expose": [
+            "css",
+            "images",
+            "javascript",
+            "webfonts"
+        ]
 	}
 }


### PR DESCRIPTION
Required for https://github.com/silverstripe/silverstripe-framework/issues/7419, but can be merged early since it's valid even by itself.

When running `composer vendor-expose`

![image](https://user-images.githubusercontent.com/936064/34234908-08725094-e653-11e7-97d6-3ddd8ec366fa.png)
