### PR TITLE
Use 'transform: scale' instead of unofficial 'zoom' in reset.css

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -1,4 +1,4 @@
-/* This reset is loosely derived from HTML5 boilerplate 
+/* This reset is loosely derived from HTML5 boilerplate
 for more information visit http://html5boilerplate.com/ */
 
 /* Every browser has its own default ‘user agent’ stylesheet, that it uses to make unstyled websites appear more legible.
@@ -23,7 +23,7 @@ body{-webkit-text-size-adjust:none;}
 
 .clear:before, .clear:after {content: "\0020"; display: block; height: 0; overflow: hidden; }
 .clear:after {clear:both;}
-.clear{zoom:1;}
+.clear{transform: scale(1);}
 
 sub, sup{font-size:75%; line-height:0; position:relative;}
 sup{top:-0.5em;}
@@ -31,7 +31,7 @@ sub{bottom:-0.25em;}
 
 pre {white-space:pre; white-space:pre-wrap; word-wrap:break-word; padding:15px;}
 textarea {overflow:auto;}
-.ie6 legend, .ie7 legend {margin-left:-7px;} 
+.ie6 legend, .ie7 legend {margin-left:-7px;}
 input[type="radio"], input.radio {vertical-align:text-bottom;}
 input[type="checkbox"], input.checkbox, .checkboxes input {vertical-align:bottom;}
 .ie7 input[type="checkbox"], .ie7 input.checkbox, .ie7 .checkboxes input {vertical-align:baseline;}


### PR DESCRIPTION
'zoom' is not supported in Firefox and triggers console errors. 'transform: scale(x)' is an official property and seems well supported among browsers.