### PR TITLE
Use the `$ThemeDir` variable instead of a static path

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -26,7 +26,7 @@ Change it, enhance it and most importantly enjoy it!
 	<% require themedCSS('typography') %>
 	<% require themedCSS('form') %>
 	<% require themedCSS('layout') %>
-	<link rel="shortcut icon" href="themes/simple/images/favicon.ico" />
+	<link rel="shortcut icon" href="$ThemeDir/images/favicon.ico" />
 </head>
 <body class="$ClassName.ShortName<% if not $Menu(2) %> no-sidebar<% end_if %>" <% if $i18nScriptDirection %>dir="$i18nScriptDirection"<% end_if %>>
 <% include Header %>

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -26,7 +26,7 @@ Change it, enhance it and most importantly enjoy it!
 	<% require themedCSS('typography') %>
 	<% require themedCSS('form') %>
 	<% require themedCSS('layout') %>
-	<link rel="shortcut icon" href="$ThemeDir/images/favicon.ico" />
+	<link rel="shortcut icon" href="$resourceURL('themes/simple/images/favicon.ico')" />
 </head>
 <body class="$ClassName.ShortName<% if not $Menu(2) %> no-sidebar<% end_if %>" <% if $i18nScriptDirection %>dir="$i18nScriptDirection"<% end_if %>>
 <% include Header %>


### PR DESCRIPTION
In this PR I replaced the static path to the favicon with the currently deprecated `$ThemeDir` variable.
Another possibility would be to use `$resourceUrl("silverstripe-themes/simple:{ path }")` instead.

This PR fixes issue #66.